### PR TITLE
Update TimeCardContinue.fx.yaml

### DIFF
--- a/samples/weekly-timesheet-sharepoint/sourcecode/WeeklyTimesheetTemplateSP/src/CanvasApps/src/ad_weeklytimecardsharepointtemplatecopy_ed80c/Src/TimeCardContinue.fx.yaml
+++ b/samples/weekly-timesheet-sharepoint/sourcecode/WeeklyTimesheetTemplateSP/src/CanvasApps/src/ad_weeklytimecardsharepointtemplatecopy_ed80c/Src/TimeCardContinue.fx.yaml
@@ -737,13 +737,13 @@
                                             Value: ddBillTo_1.Selected.Title
                                         },
                                         Manager: {
-                                            '@odata.type': "#Microsoft.Azure.Connectors.SharePoint.SPListExpandedUser",
-                                            Claims: "i:0#.f|membership|" & currentUser.Email,
-                                            Department: "",
-                                            DisplayName: currentUser.FullName,
-                                            Email: currentUser.Email,
-                                            JobTitle: "",
-                                            Picture: ""
+                                          '@odata.type': "#Microsoft.Azure.Connectors.SharePoint.SPListExpandedUser",
+                                                Claims: "i:0#.f|membership|" &  Office365Users.ManagerV2(User().Email).mail,
+                                                Department: "",
+                                                DisplayName:  Office365Users.ManagerV2(User().Email).displayName,
+                                                Email:  Office365Users.ManagerV2(User().Email).mail,
+                                                JobTitle: "",
+                                                Picture: ""
                                         },
                                         Status: {
                                             ID: 2,
@@ -788,13 +788,13 @@
                                             Value: ddBillTo_1.Selected.Title
                                         },
                                         Manager: {
-                                            '@odata.type': "#Microsoft.Azure.Connectors.SharePoint.SPListExpandedUser",
-                                            Claims: "i:0#.f|membership|" & currentUser.Email,
-                                            Department: "",
-                                            DisplayName: currentUser.FullName,
-                                            Email: currentUser.Email,
-                                            JobTitle: "",
-                                            Picture: ""
+                                          '@odata.type': "#Microsoft.Azure.Connectors.SharePoint.SPListExpandedUser",
+                                                Claims: "i:0#.f|membership|" &  Office365Users.ManagerV2(User().Email).mail,
+                                                Department: "",
+                                                DisplayName:  Office365Users.ManagerV2(User().Email).displayName,
+                                                Email:  Office365Users.ManagerV2(User().Email).mail,
+                                                JobTitle: "",
+                                                Picture: ""
                                         },
                                         Status: {
                                             ID: 2,


### PR DESCRIPTION
Screen: My Timesheets
When records are submitted with status "Submitted for approval",  manager information should be updated with current user's manager.  Instead it was being submitted as current user with status "Submitted for Approval"

> By submitting this pull request, you agree to the [contribution guidelines](https://github.com/pnp/powerplatform-samples/blob/main/CONTRIBUTING.md)

> If you aren't familiar with how to contribute to open-source repositories using GitHub, or if you find the instructions on this page confusing, sign up for one of our [Sharing is Caring](https://pnp.github.io/sharing-is-caring/#pnp-sic-events) events. It's completely free, and we'll guide you through the process.

> To submit a pull request with multiple authors, make sure that at least one commit is a co-authored commit by adding a `Co-authored-by:` trailer to the commit's message. E.g.: `Co-authored-by: name <name@example.com>`

> Put an `x` in all the items that apply (`[x]`, without spaces), make notes next to any that haven't been addressed.

- [x] Bug fix?
- [ ] New sample?
- [x] Related issues: fixes #96
- [ ] Needs API permissions?
- [ ] Has other prerequisites? (E.g. requires a list, document library, etc.)

## What's in this Pull Request?
> This resolves an issue that I logged for this repository.  On the TimeSheet Continue screen whenever you submit the updates,  it was resetting the manager information to current user and keeping status as "Submitted for Approval".  I have updated the onSubmit1_onClick event to update user's manager details whenever the updated timesheet are submitted.

## Checklist

> This checklist is mostly useful as a reminder of small things that can easily be forgotten – it is meant as a helpful tool rather than hoops to jump through.
>
> Put an `x` in all the items that apply ([x], no spaces), make notes next to any that haven't been addressed.

- [x] My pull request affects only ONE sample.
- [x] I have updated the README file.
- [x] My README has at least one static high-resolution screenshot (i.e. not a GIF)
- [x] My README contains complete setup instructions, including pre-requisites and permissions required